### PR TITLE
Add missing v0.3.0 entry to the version history

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,10 +6,16 @@
 Version History
 ###############
 
-v0.2.1
+v0.3.1
 ======
 
-* Updated Jenkinsfile.conda to use Jenkins Shared Library
+* Update Jenkinsfile.conda to use Jenkins Shared Library.
+
+v0.3.0
+======
+
+* Add `ospl-std.xml`, a non-shared-memory configuration, for unit testing and development.
+* Increase topic database size from 1Gb to 5GB in the shared memory configurations.
 
 v0.2.0
 ======


### PR DESCRIPTION
and fix the version number for the conda build changes accordingly.